### PR TITLE
Support stdin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The usage is very straight forward. Use the file name as input to **`wv`**.
 ```sh
 $ wv filename
 ```
+You can also pass `-` instead of `filename` to read data from standard input.
 **`filename`** can be a normal sized file, or a streaming file that never ends.
 In the latter case, **`wv`** will show the data lively. Note that if you leave **`wv`** plotting stream data, it will continueously consume memory, until no memory is available and killed by linux kernel.
 

--- a/argparse.hpp
+++ b/argparse.hpp
@@ -48,6 +48,7 @@ SOFTWARE.
 #include <type_traits>
 #include <variant>
 #include <vector>
+#include <utility>
 
 namespace argparse {
 

--- a/main.cpp
+++ b/main.cpp
@@ -108,7 +108,12 @@ int main(int argc, char **argv) {
         tb_shutdown();
         return 0;
     }
-	FILE *fd = fopen((char *)fname.c_str(), "rb");
+    FILE *fd;
+    if (fname == "-") {
+        fd = stdin;
+    } else {
+        fd = fopen((char *)fname.c_str(), "rb");
+    }
     if (fd == NULL) exit(-1);
 
     Track track(65536);


### PR DESCRIPTION
## Summary
- allow `wv` to read from standard input when `-` is provided as the filename
- document stdin usage in README
- fix compile error by including `<utility>` in argparse.hpp

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_b_687f0cf485ec8332b1c02ddbc302d16c